### PR TITLE
Create stub workflow for CICD build and test

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,21 @@
+name: "Build & Test"
+
+on:
+  workflow_dispatch:
+
+permissions:
+  packages: read
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  tmp:
+    name: Stub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Workflow Stub
+        run: |
+          echo "Workflow Stub"


### PR DESCRIPTION
Creating a shell of the initial Build & Test workflow to be merged quickly allowing development of actual workflow in follow-on branch.

Need to have workflow file merged before github will allow triggering it in a development branch.

Relates to: https://github.com/eosnetworkfoundation/evm-bridge-contracts/issues/1