### PR TITLE
Use bytes instead of static-sized arrays in contract tables

### DIFF
--- a/antelope_contracts/contracts/erc20/include/erc20/erc20.hpp
+++ b/antelope_contracts/contracts/erc20/include/erc20/erc20.hpp
@@ -21,9 +21,10 @@ class [[eosio::contract]] erc20 : public contract {
     [[eosio::action]] void onbridgemsg(name receiver, const bytes& sender, const time_point& timestamp, const bytes& value, const bytes& data);
     [[eosio::action]] void init();
 
-    struct [[eosio::table]] [[eosio::contract("evm_contract")]] config
+    struct [[eosio::table]] config
    {
-      uint8_t erc20_addr[kAddressLength];
+      bytes erc20_addr;
+
       EOSLIB_SERIALIZE(config, (erc20_addr));
    };
 

--- a/antelope_contracts/contracts/erc20/src/erc20.cpp
+++ b/antelope_contracts/contracts/erc20/src/erc20.cpp
@@ -45,7 +45,8 @@ void erc20::init() {
         .erc20_addr = {},
     };
 
-    memcpy(new_config.erc20_addr, deploy_addr.bytes, kAddressLength);
+    new_config.erc20_addr.resize(kAddressLength);
+    memcpy(new_config.erc20_addr.data(), deploy_addr.bytes, kAddressLength);
 
     _config.set(new_config, get_self());
 }


### PR DESCRIPTION
This change allows CDT to generate a valid ABI for the contract, which allows the tests to pass when building with CDT 4.0 or later.