### PR TITLE
[0.1] Update README to prescribed particular solcjs version

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ The `erc20` contracts (both within `solidity_contracts` and `antelope_contracts`
   + We chose to use solcjs because it is more actively maintained than the solc available from the package manager.
     * First install node.js and npm.
     * Then install solcjs: `npm install -g solc`
+  + Make sure to install version 0.8.21.
+    * Confirm with `solcjs --version`. You should get `0.8.21+commit.d9974bed.Emscripten.clang`
 - Install `jq` used to compile solidity contracts
   + `apt-get install jq`
 - Install `xxd` used to compile solidity contracts

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The `erc20` contracts (both within `solidity_contracts` and `antelope_contracts`
   + Used to compile the .sol files. 
   + We chose to use solcjs because it is more actively maintained than the solc available from the package manager.
     * First install node.js and npm.
-    * Then install solcjs: `npm install -g solc`
+    * Then install solcjs: `npm install -g solc@0.8.21`
   + Make sure to install version 0.8.21.
     * Confirm with `solcjs --version`. You should get `0.8.21+commit.d9974bed.Emscripten.clang`
 - Install `jq` used to compile solidity contracts


### PR DESCRIPTION
It is important to use the same version of solcjs to get the same bytecode which is then embedded inside of the erc20 contract (and therefore impacts the expected hash of the generated WASM file).