### PR TITLE
use leap-dev from 5.0.x release; update README; upload builddir as artifact

### DIFF
--- a/.cicd/defaults.json
+++ b/.cicd/defaults.json
@@ -1,6 +1,6 @@
 {
     "leap-dev":{
-       "target":"main",
+       "target":"5",
        "prerelease":false
     },
     "cdt":{

--- a/.cicd/platforms/ubuntu22.Dockerfile
+++ b/.cicd/platforms/ubuntu22.Dockerfile
@@ -8,9 +8,10 @@ RUN apt-get update && apt-get upgrade -y && \
                        g++-11               \
                        git                  \
                        jq                   \
+                       libcurl4-gnutls-dev  \
                        wget                 \
                        xxd                  \
-                       libcurl4-gnutls-dev  
+                       zstd
 
 #Install Node.js
 #https://github.com/nodesource/distributions/blob/master/README.md#installation-instructions

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -141,7 +141,7 @@ jobs:
 
     steps:
       - name: Checkout evm-bridge-contracts
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: 'recursive'
@@ -156,24 +156,22 @@ jobs:
           prereleases: ${{fromJSON(needs.versions.outputs.cdt-prerelease)}}
           file: 'cdt_.*amd64.deb'
 
-      - name: Install CDT
-        run: apt-get install -y ./cdt*.deb
-
       - name: Download leap-dev.deb
         uses: AntelopeIO/asset-artifact-download-action@v3
         with:
           owner: AntelopeIO
           repo: leap
-          file: 'leap-dev.*(x86_64|amd64).deb'
+          file: 'leap-dev.*ubuntu22.*amd64.deb'
           target: ${{needs.versions.outputs.leap-dev-target}}
           prereleases: ${{fromJSON(needs.versions.outputs.leap-dev-prerelease)}}
           artifact-name: leap-dev-ubuntu22-amd64
           container-package: experimental-binaries
 
-      - name: Install leap-dev.deb
+      - name: Install .deb packages
         run: |
-          apt install -y ./leap-dev*.deb
-          rm ./leap-dev*.deb
+          apt-get update && apt-get -y upgrade
+          apt install -y ./*.deb
+          rm ./*.deb
 
       - name: Download EOS EVM Contract
         uses: AntelopeIO/asset-artifact-download-action@v3
@@ -184,7 +182,6 @@ jobs:
           prereleases: ${{fromJSON(needs.versions.outputs.eos-evm-contract-prerelease)}}
           file: 'contract.tar.gz'
           artifact-name: contract.test-actions-off.tar.gz
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract EOS EVM Contract
         id: evm-contract
@@ -199,10 +196,16 @@ jobs:
       - name: Build EVM Bridge Contracts
         run: |
           pushd evm-bridge-contracts
-          mkdir build
-          pushd build
-          cmake -Deosevm_DIR=${{ steps.evm-contract.outputs.EVM_CONTRACT }} ..
-          make -j
+          cmake -B build -Deosevm_DIR=${{ steps.evm-contract.outputs.EVM_CONTRACT }}
+          cmake --build build -- -j
+          tar -pc build | zstd --long -T0 -9 > build.tar.zst
+
+      - name: Upload builddir
+        uses: actions/upload-artifact@v4
+        with:
+          name: builddir
+          path: evm-bridge-contracts/build.tar.zst
+          compression-level: 0
 
       - name: EVM Bridge Contracts Tests
         run: |

--- a/README.md
+++ b/README.md
@@ -6,10 +6,7 @@ The `erc20` contracts (both within `solidity_contracts` and `antelope_contracts`
 ## Dependencies
 
 - CMake 3.16 or later
-- [Leap](https://github.com/AntelopeIO/leap) 4.0 or later
-  + Currently there is an issue in the 4.0 release of Leap that causes test to fail to build with C++20 (which is necessary due to the silkworm dependency of the erc20 contract).
-  + To work around this issue, one option is to build Leap from the main branch of the [leap](https://github.com/AntelopeIO/leap) repo which has changes to support building Leap with C++20.
-  + An alternative workaround for this issue is to apply the fix mentioned in https://github.com/AntelopeIO/leap/issues/1497 to a copy of the [release/4.0](https://github.com/AntelopeIO/leap/tree/release/4.0) branch before building Leap. The branch [4.0-with-evm-fix](https://github.com/AntelopeIO/leap/tree/4.0-with-evm-fix) is also available with the fix already applied to a recent copy of the release/4.0 branch. 
+- [Leap](https://github.com/AntelopeIO/leap) 5.0 or later
 - [CDT](https://github.com/AntelopeIO/cdt) 4.0 or later
 - solc
   + Used to compile the .sol files. 


### PR DESCRIPTION
Minor changes to use a release leap version (5.0). Resolves #24 while in here