### PR TITLE
pass in linked eos address and evm address instead of hardcode

### DIFF
--- a/solidity_contracts/erc20/contract.sol
+++ b/solidity_contracts/erc20/contract.sol
@@ -1488,7 +1488,9 @@ contract BridgeERC20 is Initializable, ERC20Upgradeable, UUPSUpgradeable {
      address public evmAddress;
      uint8   public precision;
      uint256 public egressFee;
-     function initialize(uint8   _precision,
+     function initialize(address _linkedEOSAddress,
+                         address _evmAddress,
+                         uint8   _precision,
                          uint256 _egressFee,
                          string memory _name, 
                          string memory _symbol,
@@ -1496,12 +1498,40 @@ contract BridgeERC20 is Initializable, ERC20Upgradeable, UUPSUpgradeable {
                           ) initializer public {
         __ERC20_init(_name, _symbol);
         __UUPSUpgradeable_init();
-        evmAddress = 0xbBBBbBbbbBBBBbbbbbbBBbBB5530EA015b900000;
-        linkedEOSAddress = 0xbbBbbbBbbBBbBBbBBBbbbBbB5530eA015740a800;
-        linkedEOSAccountName = "eosio.erc2o";
+        evmAddress = _evmAddress;
+        linkedEOSAddress = _linkedEOSAddress;
+        linkedEOSAccountName = _addressToName(linkedEOSAddress);
         precision = _precision;
         egressFee = _egressFee;
         eos_token_contract = _eos_token_contract;
+    }
+
+    function _addressToName(address input) internal pure returns (string memory) {
+        require(_isReservedAddress(input));
+        uint64 a = uint64(uint160(input));
+        bytes memory bstr = new bytes(12);
+
+        uint count = 0;
+        for (uint i = 0; i < 12 ; i++) {
+            uint64 c = (a >> (64 - 5*(i+1))) & uint64(31);
+            if (c == 0) {
+                bstr[i] = bytes1(uint8(46)); // .
+            }
+            else if (c <= 5) {
+                bstr[i] = bytes1(uint8(c + 48)); // '0' + b
+                count = i + 1;
+            }
+            else {
+                bstr[i] = bytes1(uint8(c - 6 + 97)); // 'a' + b - 6
+                count = i + 1;
+            }
+        }
+
+        bytes memory bstrTrimmed = new bytes(count);
+        for (uint j = 0; j < count; j++) {
+            bstrTrimmed[j] = bstr[j];
+        }
+        return string(bstrTrimmed);
     }
 
     function setFee(uint256 _egressFee) public {


### PR DESCRIPTION
Resolve #46 

Though we still cannot "configure" them during runtime, but at least they are not hardcoded in solidity anymore.

We can make them configurable when there's real requiremnents.