### PR TITLE
[0.2.1] Update silkworm submodule and Spring dependency

### DIFF
--- a/.cicd/defaults.json
+++ b/.cicd/defaults.json
@@ -1,6 +1,6 @@
 {
     "antelope-spring-dev":{
-       "target":"main",
+       "target":"1",
        "prerelease":false
     },
     "cdt":{


### PR DESCRIPTION
Updated the silkworm submodule to the latest head of the `release/1.0` branch which includes the license updates (BSL).

Also, changed the Spring dependency to use the latest stable 1.x release instead of whatever is on the `main` branch of the Spring repo.