### PR TITLE
[0.2.1 -> main] Change to BSL licensing scheme; update silkworm submodule

### DIFF
--- a/.cicd/defaults.json
+++ b/.cicd/defaults.json
@@ -1,6 +1,6 @@
 {
     "antelope-spring-dev":{
-       "target":"1",
+       "target":"main",
        "prerelease":false
     },
     "cdt":{

--- a/.cicd/defaults.json
+++ b/.cicd/defaults.json
@@ -1,6 +1,6 @@
 {
     "antelope-spring-dev":{
-       "target":"main",
+       "target":"1",
        "prerelease":false
     },
     "cdt":{

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,97 @@
-MIT License
+License text copyright (c) 2023 MariaDB plc, All Rights Reserved. "Business
+Source License" is a trademark of MariaDB plc.
 
-Copyright (c) 2023 EOS Network Foundation
+Parameters
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Licensor:              EOS NETWORK FOUNDATION ("ENF")
+                       
+Licensed Work:         EOS-EVM Bridge Contracts Copyright ENF, 2024, All Rights
+                       Reserved
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+Additional Use Grant:  Licensee (You) is granted, free of charge, to deal in
+                       the Licensed Work without restriction, including
+                       without limitation the rights to use, copy, modify,
+                       merge, publish, distribute, sublicense, and/or sell
+                       copies of the Licensed Work, and to permit persons to
+                       whom the Licensed Work is furnished to do so, subject
+                       to the following conditions:
+                       
+                       Your use of the Licensed Work is Directly in Service
+                       of or Materially Dependent on the EOS Blockchain
+                       Network
+                       
+                       The copyright notice and this permission notice shall
+                       be included in all copies or substantial portions of
+                       the Software.
+                       
+                       For the purposes of this license:
+                       
+                       "EOS Blockchain Network" is defined as any blockchain
+                       network created with the EOSIO, or Antelope,
+                       protocols, or any future protocols derived
+                       substantially from them whose genesis block id as
+                       defined by the Licensed Work is 00000001405147477ab2f5...
+                       f51cda427b638191c66d2c59aa392d5c2c98076cb0 
+                       
+                       "Directly in Service" is defined as any use which is
+                       necessary for the EOS Blockchain to persist and
+                       continue operations including but not limited to
+                       hosting network nodes, archives, RPC endpoints, and
+                       integration with 3rd party services.
+                       
+                       "Materially Dependent" is defined as use that would
+                       cease to operate effectively or economically if the
+                       EOS blockchain component was removed temporarily or
+                       permanently.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+Change Date:           Four years from the date the Licensed Work is published
+
+Change License:        MIT 2.0
+
+For information about alternative licensing arrangements for the Licensed Work,
+please contact licensing@eosnetwork.com.
+
+Notice
+
+Business Source License 1.1
+ 
+Terms
+
+The Licensor hereby grants you the right to copy, modify, create derivative
+works, redistribute, and make non-production use of the Licensed Work. The
+Licensor may make an Additional Use Grant, above, permitting limited production
+use.
+
+Effective on the Change Date, or the fourth anniversary of the first publicly
+available distribution of a specific version of the Licensed Work under this
+License, whichever comes first, the Licensor hereby grants you rights under
+the terms of the Change License, and the rights granted in the paragraph
+above terminate.
+
+If your use of the Licensed Work does not comply with the requirements
+currently in effect as described in this License, you must purchase a
+commercial license from the Licensor, its affiliated entities, or authorized
+resellers, or you must refrain from using the Licensed Work.
+
+All copies of the original and modified Licensed Work, and derivative works
+of the Licensed Work, are subject to this License. This License applies
+separately for each version of the Licensed Work and the Change Date may vary
+for each version of the Licensed Work released by Licensor.
+
+You must conspicuously display this License on each original or modified copy
+of the Licensed Work. If you receive the Licensed Work in original or
+modified form from a third party, the terms and conditions set forth in this
+License apply to your use of that work.
+
+Any use of the Licensed Work in violation of this License will automatically
+terminate your rights under this License for the current and all other
+versions of the Licensed Work.
+
+This License does not grant you any right in any trademark or logo of
+Licensor or its affiliates (provided that you may use a trademark or logo of
+Licensor as expressly required by this License).
+
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
+AN "AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND TITLE.


### PR DESCRIPTION
Forwards PRs #54 and #55 to `main` branch.

However, instead of using the silkworm submodule commit of #55, the silkworm submodule is updated to use the current head of the `master` branch of the silkworm repo.

Additionally, the changes of #55 to use the latest Spring 1.x version as the Spring dependency are reverted back for the `main` branch of the `evm-bridge-contracts` repo. The `main` branch of the `evm-bridge-contracts` repo continues to use the `main` branch of Spring for its Spring dependency.