### PR TITLE
[0.2.1] Update EVM Contract dependency

### DIFF
--- a/.cicd/defaults.json
+++ b/.cicd/defaults.json
@@ -8,7 +8,7 @@
        "prerelease":false
     },
     "eos-evm-contract":{
-      "target":"main",
+      "target":"release/1.0",
       "prerelease":false
     }
  }


### PR DESCRIPTION
Use the head of the `release/1.0` branch of `eos-evm-contract` for the EVM Contract dependency rather than the head of its `main` branch. The head of the `main` branch is not stable enough as a dependency for a stable release of the EVM Bridge Contracts.

The `main` branch of EVM Contract should only be used for the `main` branch of EVM Bridge Contracts.