### PR TITLE
[0.2.1 -> main] Update EVM Contract dependency; Fix Spring version dependency

### DIFF
--- a/.cicd/defaults.json
+++ b/.cicd/defaults.json
@@ -1,6 +1,6 @@
 {
     "antelope-spring-dev":{
-       "target":"main",
+       "target":"1",
        "prerelease":false
     },
     "cdt":{
@@ -8,7 +8,7 @@
        "prerelease":false
     },
     "eos-evm-contract":{
-      "target":"release/1.0",
+      "target":"main",
       "prerelease":false
     }
  }


### PR DESCRIPTION
Forwards #57 to the `main` branch.

However, it reverts the dependency on EVM Contract back to `main` since that is appropriate for the `main` branch of `evm-bridge-contracts`.

If those were the only changes, this PR should have no diff.

However, this PR also changes the version dependency for Spring. It goes against the decision in https://github.com/eosnetworkfoundation/evm-bridge-contracts/pull/56 to keep the Spring dependency the same (still depending on the `main` branch). There does not seem to be a strong reason for why the `main` branch of EVM Bridge Contracts should depend on the `main` branch of Spring. It makes more sense for it to depend on the latest stable version.