### PR TITLE
Allow register customized Bridged ERC20 implementation

### DIFF
--- a/antelope_contracts/contracts/erc20/include/erc20/erc20.hpp
+++ b/antelope_contracts/contracts/erc20/include/erc20/erc20.hpp
@@ -49,6 +49,11 @@ class [[eosio::contract]] erc20 : public contract {
                                     std::string evm_token_name, std::string evm_token_symbol, 
                                     const eosio::asset &ingress_fee, const eosio::asset &egress_fee, uint8_t erc20_precision);
 
+    [[eosio::action]] void regtokenwcode(eosio::name eos_contract_name,
+                                        std::string impl_address,
+                                    std::string evm_token_name, std::string evm_token_symbol, 
+                                    const eosio::asset &ingress_fee, const eosio::asset &egress_fee, uint8_t erc20_precision);
+
     [[eosio::action]] void addegress(const std::vector<name> &accounts);
     [[eosio::action]] void removeegress(const std::vector<name> &accounts);
     [[eosio::action]] void setegressfee(eosio::name token_contract, eosio::symbol_code token_symbol_code, const eosio::asset &egress_fee);
@@ -140,6 +145,8 @@ class [[eosio::contract]] erc20 : public contract {
     void handle_call_upgrade(const bytes& proxy_address);
 
 private:
+void regtokenwithcodebytes(eosio::name token_contract,  const bytes& address_bytes, std::string evm_token_name, std::string evm_token_symbol, const eosio::asset& ingress_fee, const eosio::asset &egress_fee, uint8_t erc20_precision);
+   
     eosio::name receiver_account()const;
 };
 

--- a/antelope_contracts/contracts/erc20/include/erc20/erc20.hpp
+++ b/antelope_contracts/contracts/erc20/include/erc20/erc20.hpp
@@ -49,7 +49,7 @@ class [[eosio::contract]] erc20 : public contract {
                                     std::string evm_token_name, std::string evm_token_symbol, 
                                     const eosio::asset &ingress_fee, const eosio::asset &egress_fee, uint8_t erc20_precision);
 
-    [[eosio::action]] void regtokenwcode(eosio::name eos_contract_name,
+    [[eosio::action]] void regwithcode(eosio::name eos_contract_name,
                                         std::string impl_address,
                                     std::string evm_token_name, std::string evm_token_symbol, 
                                     const eosio::asset &ingress_fee, const eosio::asset &egress_fee, uint8_t erc20_precision);

--- a/antelope_contracts/contracts/erc20/src/erc20.cpp
+++ b/antelope_contracts/contracts/erc20/src/erc20.cpp
@@ -208,7 +208,7 @@ void erc20::regtokenwithcodebytes(eosio::name token_contract, const bytes& addre
     });
 }
 
-[[eosio::action]] void erc20::regtokenwcode(eosio::name token_contract, std::string impl_address, std::string evm_token_name, std::string evm_token_symbol, const eosio::asset& ingress_fee, const eosio::asset &egress_fee, uint8_t erc20_precision) {
+[[eosio::action]] void erc20::regwithcode(eosio::name token_contract, std::string impl_address, std::string evm_token_name, std::string evm_token_symbol, const eosio::asset& ingress_fee, const eosio::asset &egress_fee, uint8_t erc20_precision) {
     require_auth(get_self());
     auto address_bytes = from_hex(impl_address);
     eosio::check(!!address_bytes, "implementation address must be valid 0x EVM address");

--- a/antelope_contracts/contracts/erc20/src/erc20.cpp
+++ b/antelope_contracts/contracts/erc20/src/erc20.cpp
@@ -106,8 +106,11 @@ void erc20::upgradeto(std::string impl_address) {
     });
 }
 
-[[eosio::action]] void erc20::regtoken(eosio::name token_contract, std::string evm_token_name, std::string evm_token_symbol, const eosio::asset& ingress_fee, const eosio::asset &egress_fee, uint8_t erc20_precision) {
+void erc20::regtokenwithcodebytes(eosio::name token_contract, const bytes& address_bytes, std::string evm_token_name, std::string evm_token_symbol, const eosio::asset& ingress_fee, const eosio::asset &egress_fee, uint8_t erc20_precision) {
     require_auth(get_self());
+    
+    eosio::check(address_bytes.size() == kAddressLength, "invalid length of implementation address");
+
     config_t config = get_config();
 
     eosio::check(eosio::is_account(token_contract), "invalid token_contract");
@@ -128,11 +131,6 @@ void erc20::upgradeto(std::string impl_address) {
     auto index_symbol = token_table.get_index<"by.symbol"_n>();
     check(index_symbol.find(token_symbol_key(token_contract, ingress_fee.symbol.code())) == index_symbol.end(), "token already registered");
 
-    impl_contract_table_t contract_table(_self, _self.value);
-    eosio::check(contract_table.begin() != contract_table.end(), "no implementaion contract available");
-    auto contract_itr = contract_table.end();
-    --contract_itr;
-
     auto reserved_addr = silkworm::make_reserved_address(receiver_account().value);
     auto evm_reserved_addr = silkworm::make_reserved_address(config.evm_account.value);
     bytes call_data;
@@ -140,7 +138,7 @@ void erc20::upgradeto(std::string impl_address) {
 
     // constructor(address erc20_impl_contract, memory _data)
     call_data.insert(call_data.end(), 32 - kAddressLength, 0);  // padding for address
-    call_data.insert(call_data.end(), contract_itr->address.begin(), contract_itr->address.end());
+    call_data.insert(call_data.end(), address_bytes.begin(), address_bytes.end());
 
     bytes constructor_data;
     // initialize(address,address,uint8,uint256,string,string,string) == 0x1fa01e36
@@ -208,6 +206,28 @@ void erc20::upgradeto(std::string impl_address) {
         v.fee_balance = v.balance;
         v.erc20_precision = erc20_precision;
     });
+}
+
+[[eosio::action]] void erc20::regtokenwcode(eosio::name token_contract, std::string impl_address, std::string evm_token_name, std::string evm_token_symbol, const eosio::asset& ingress_fee, const eosio::asset &egress_fee, uint8_t erc20_precision) {
+    require_auth(get_self());
+    auto address_bytes = from_hex(impl_address);
+    eosio::check(!!address_bytes, "implementation address must be valid 0x EVM address");
+    eosio::check(address_bytes->size() == kAddressLength, "invalid length of implementation address");
+
+    regtokenwithcodebytes(token_contract, *address_bytes, evm_token_name, evm_token_symbol, ingress_fee, egress_fee, erc20_precision);
+
+}
+
+[[eosio::action]] void erc20::regtoken(eosio::name token_contract, std::string evm_token_name, std::string evm_token_symbol, const eosio::asset& ingress_fee, const eosio::asset &egress_fee, uint8_t erc20_precision) {
+    require_auth(get_self());
+    
+    impl_contract_table_t contract_table(_self, _self.value);
+    eosio::check(contract_table.begin() != contract_table.end(), "no implementaion contract available");
+    auto contract_itr = contract_table.end();
+    --contract_itr;
+
+    regtokenwithcodebytes(token_contract, contract_itr->address, evm_token_name, evm_token_symbol, ingress_fee, egress_fee, erc20_precision);
+
 }
 
 void erc20::onbridgemsg(const bridge_message_t &message) {

--- a/antelope_contracts/tests/erc20/erc20_tester.cpp
+++ b/antelope_contracts/tests/erc20/erc20_tester.cpp
@@ -212,7 +212,7 @@ erc20_tester::erc20_tester(bool use_real_evm, eosio::chain::name evm_account_, s
     produce_block();
 
     evm_eoa deployer;
-    evmc::address impl_addr = silkworm::create_address(deployer.address, deployer.next_nonce); 
+    impl_addr = silkworm::create_address(deployer.address, deployer.next_nonce); 
 
     if (use_real_evm) {
         try {

--- a/antelope_contracts/tests/erc20/erc20_tester.hpp
+++ b/antelope_contracts/tests/erc20/erc20_tester.hpp
@@ -137,6 +137,8 @@ class erc20_tester : public eosio::testing::base_tester {
 
     unsigned int exec_count = 0; // ensure uniqueness in exec
 
+    evmc::address impl_addr;
+
     eosio::chain::asset make_asset(int64_t amount) const { return eosio::chain::asset(amount, native_symbol); }
     eosio::chain::asset make_asset(int64_t amount, const eosio::chain::symbol& target_symbol) const { return eosio::chain::asset(amount, target_symbol); }
     eosio::chain::transaction_trace_ptr transfer_token(eosio::chain::name token_account_name, eosio::chain::name from, eosio::chain::name to, eosio::chain::asset quantity, std::string memo = "");

--- a/antelope_contracts/tests/erc20/integrated_tests.cpp
+++ b/antelope_contracts/tests/erc20/integrated_tests.cpp
@@ -428,6 +428,77 @@ try {
 }
 FC_LOG_AND_RETHROW()
 
+BOOST_FIXTURE_TEST_CASE(it_regtokenwcode, it_tester)
+try {
+    evm_eoa evm1;
+    auto addr_alice = silkworm::make_reserved_address("alice"_n.to_uint64_t());
+
+    // Give evm1 some EOS
+    transfer_token(eos_token_account, "alice"_n, evm_account, make_asset(1000000, eos_token_symbol), evm1.address_0x().c_str());
+    produce_block();
+
+
+    // USDT balance should be zero
+    auto bal = balanceOf(evm1.address_0x().c_str());
+    BOOST_REQUIRE(bal == 0);
+
+    produce_block();
+
+    // alice send 1.0000 USDT to evm1
+    transfer_token(token_account, "alice"_n, erc20_account, make_asset(10000, token_symbol), evm1.address_0x().c_str());
+
+    // evm1 has 0.990000 USDT
+    BOOST_REQUIRE(balanceOf(evm1.address_0x().c_str()) == 990000);
+
+    // alice has 9999.0000 USDT
+    BOOST_REQUIRE(9999'0000 == get_balance("alice"_n, token_account, symbol::from_string("4,USDT")).get_amount());
+
+    // unregtoken
+    push_action(
+        erc20_account, "unregtoken"_n, erc20_account, mvo()("eos_contract_name", token_account)("token_symbol_code", (std::string)(token_symbol.name())));
+
+    // EOS->EVM not allowed after unregtoken
+    BOOST_REQUIRE_EXCEPTION(
+        transfer_token(token_account, "alice"_n, erc20_account, make_asset(20000, token_symbol), evm1.address_0x().c_str()),
+        eosio_assert_message_exception, 
+        eosio_assert_message_is("received unregistered token"));
+
+    // EVM->EOS not allowed after unregtoken
+    auto fee = egressFee();
+    BOOST_REQUIRE_EXCEPTION(
+        bridgeTransferERC20(evm1, addr_alice, 10000, "aaa", fee),
+        eosio_assert_message_exception, 
+        eosio_assert_message_is("ERC-20 token not registerred"));
+
+    // register token again (imply a different ERC-EVM address)
+    push_action(erc20_account, "regtokenwcode"_n, erc20_account, mvo()("eos_contract_name",token_account.to_string())("impl_address",fc::variant(impl_addr).as_string())("evm_token_name","EVM USDT V2")("evm_token_symbol","WUSDT")("ingress_fee","0.0100 USDT")("egress_fee","0.0100 EOS")("erc20_precision",6));
+
+    // EOS->EVM: alice transfer 2 USDT to evm1 in EVM (new ERC-EVM address)
+    transfer_token(token_account, "alice"_n, erc20_account, make_asset(20000, token_symbol), evm1.address_0x().c_str());
+
+    // alice has 9997.0000 USDT
+    BOOST_REQUIRE(9997'0000 == get_balance("alice"_n, token_account, symbol::from_string("4,USDT")).get_amount());
+
+    // evm1 has 0.990000 USDT under the original ERC-20 address
+    BOOST_REQUIRE(balanceOf(evm1.address_0x().c_str()) == 990000);
+
+    // refresh evm token address
+    evm_address = getSolidityContractAddress();
+
+    // evm1 has 1.990000 USDT under the new ERC-20 address
+    BOOST_REQUIRE(balanceOf(evm1.address_0x().c_str()) == 1990000);
+
+    // EVM->EOS: evm1 tranfer 0.010000 USDT to alice
+    bridgeTransferERC20(evm1, addr_alice, 10000, "aaa", fee);
+
+    // evm1 has 1.980000 USDT under the new ERC-20 address
+    BOOST_REQUIRE(balanceOf(evm1.address_0x().c_str()) == 1980000);    
+
+    // alice has 9997.0000 USDT
+    BOOST_REQUIRE(9997'0100 == get_balance("alice"_n, token_account, symbol::from_string("4,USDT")).get_amount());
+}
+FC_LOG_AND_RETHROW()
+
 BOOST_FIXTURE_TEST_CASE(it_eos_to_evm, it_tester)
 try {
     evm_eoa evm1;

--- a/antelope_contracts/tests/erc20/integrated_tests.cpp
+++ b/antelope_contracts/tests/erc20/integrated_tests.cpp
@@ -428,7 +428,7 @@ try {
 }
 FC_LOG_AND_RETHROW()
 
-BOOST_FIXTURE_TEST_CASE(it_regtokenwcode, it_tester)
+BOOST_FIXTURE_TEST_CASE(it_regwithcode, it_tester)
 try {
     evm_eoa evm1;
     auto addr_alice = silkworm::make_reserved_address("alice"_n.to_uint64_t());
@@ -471,7 +471,7 @@ try {
         eosio_assert_message_is("ERC-20 token not registerred"));
 
     // register token again (imply a different ERC-EVM address)
-    push_action(erc20_account, "regtokenwcode"_n, erc20_account, mvo()("eos_contract_name",token_account.to_string())("impl_address",fc::variant(impl_addr).as_string())("evm_token_name","EVM USDT V2")("evm_token_symbol","WUSDT")("ingress_fee","0.0100 USDT")("egress_fee","0.0100 EOS")("erc20_precision",6));
+    push_action(erc20_account, "regwithcode"_n, erc20_account, mvo()("eos_contract_name",token_account.to_string())("impl_address",fc::variant(impl_addr).as_string())("evm_token_name","EVM USDT V2")("evm_token_symbol","WUSDT")("ingress_fee","0.0100 USDT")("egress_fee","0.0100 EOS")("erc20_precision",6));
 
     // EOS->EVM: alice transfer 2 USDT to evm1 in EVM (new ERC-EVM address)
     transfer_token(token_account, "alice"_n, erc20_account, make_asset(20000, token_symbol), evm1.address_0x().c_str());


### PR DESCRIPTION
PR from exsat.

Resolves #68 

This functionality was requested to support ERC20 tokens with special requirements for their implementation. Later we decided that we should let the user launch the token in EVM end first then bridge back to EOS instead of use this bridge. But the code is done and audited anyway. So it should be nice to pull it back. 